### PR TITLE
chore: upgrade to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - run: npm ci
       - run: npm run lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /usr/src/app
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,12 @@
     "": {
       "name": "extralife-helper-bot",
       "version": "1.0.0",
-      "license": "Apache-2.0",
+      "license": "MIT",
       "dependencies": {
         "@discordjs/rest": "^2.4.0",
-        "discord-api-types": "^0.37.11",
+        "discord-api-types": "^0.38.22",
         "discord.js": "^14.5.0",
-        "dotenv": "^16.4.5",
+        "dotenv": "^17.2.2",
         "extra-life-api": "^8.0.0",
         "log-timestamp": "^0.3.0",
         "tmi.js": "^1.8.5"
@@ -21,6 +21,9 @@
         "eslint": "^9.34.0",
         "globals": "^16.3.0",
         "jest": "^30.1.2"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -554,15 +557,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.38.22",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
-      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/collection": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
@@ -590,15 +584,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
-      "version": "0.38.22",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
-      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/@discordjs/rest": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
@@ -621,15 +606,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
-      "version": "0.38.22",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
-      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@discordjs/util": {
       "version": "1.1.1",
@@ -665,15 +641,6 @@
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
-    },
-    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
-      "version": "0.38.22",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
-      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
     },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
@@ -2549,10 +2516,13 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.120",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
-      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
-      "license": "MIT"
+      "version": "0.38.22",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
+      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
     },
     "node_modules/discord.js": {
       "version": "14.22.1",
@@ -2600,19 +2570,10 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.38.22",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.22.tgz",
-      "integrity": "sha512-2gnYrgXN3yTlv2cKBISI/A8btZwsSZLwKpIQXeI1cS8a7W7wP3sFVQOm3mPuuinTD8jJCKGPGNH399zE7Un1kA==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -15,15 +15,18 @@
   },
   "author": "St. John Johnson <st.john.johnson@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=24"
+  },
   "bugs": {
     "url": "https://github.com/stjohnjohnson/extralife-helper-bot/issues"
   },
   "homepage": "https://github.com/stjohnjohnson/extralife-helper-bot#readme",
   "dependencies": {
     "@discordjs/rest": "^2.4.0",
-    "discord-api-types": "^0.37.11",
+    "discord-api-types": "^0.38.22",
     "discord.js": "^14.5.0",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.2.2",
     "extra-life-api": "^8.0.0",
     "log-timestamp": "^0.3.0",
     "tmi.js": "^1.8.5"


### PR DESCRIPTION
## Summary
- use Node.js 24 in Docker and CI
- require Node 24+ and update dependencies

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8671a80cc8323b4fe3c403f271442