### PR TITLE
chore: build Docker image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,11 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: extralife-helper-bot:latest


### PR DESCRIPTION
## Summary
- build Docker image during CI using Docker Buildx action to enable post-merge pushes

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `docker build -t extralife-helper-bot .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86861f95c832391c819824330fb2a