### PR TITLE
feat: add Philips Hue light celebrations for donations

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A unified helper bot for managing your ExtraLife 24 hour marathon stream, bridgi
 ## Features
 
 - Post donation notifications to Discord channels and Twitch chat
+- Flash your Hue lights in ExtraLife colors when donations are received
 - Update Discord channel names with fundraising progress
 - Cross-platform commands that work on both Discord and Twitch (`!goal`, `!promote`)
 - Custom command responses that work across both platforms
@@ -50,6 +51,20 @@ The bot requires at least one service (Discord or Twitch) to be configured. Set 
   - Commands must start with a letter and contain only lowercase letters and numbers
   - Cannot conflict with built-in commands (`goal`, `promote`)
   - Commands are case-insensitive when used (e.g., `!DONATE` and `!donate` work the same)
+
+### Philips Hue Light Celebration (required)
+- `HUE_USERNAME`: Your Hue bridge username/API key
+- `HUE_IPADDRESS`: IP address of your Hue bridge (e.g., `192.168.1.100`)
+- `HUE_GROUPID`: The Hue group ID containing lights for donation celebrations
+
+**Setting up Hue Integration:**
+1. Find your Hue bridge IP address (check your router admin panel or use the [Hue app](https://apps.apple.com/us/app/philips-hue/id1055281310))
+2. Create a new user on your bridge:
+   - Press the physical button on your Hue bridge
+   - Within 30 seconds, send a POST request to `http://[bridge-ip]/api` with body: `{"devicetype":"ExtraLife Helper Bot"}`
+   - The response will contain your `username` (API key)
+3. Find your group ID by making a GET request to `http://[bridge-ip]/api/[username]/groups`
+4. Configure the environment variables for this bot appropriately
 
 ## Running
 
@@ -166,6 +181,7 @@ Some commands are restricted to admin users only for security purposes. Admin us
 
 **Admin-only commands:**
 - `!promote` - Voice channel management (moves users from waiting room to live chat)
+- `!testlights` - Test Philips Hue light celebration (verifies connection and triggers a demo light show)
 
 **Admin Configuration Examples:**
 ```bash

--- a/app.js
+++ b/app.js
@@ -6,12 +6,14 @@ const { parseConfiguration } = require('./src/config.js');
 const { handleCommand } = require('./src/commands.js');
 const { handlePresenceUpdate } = require('./src/gameUpdates.js');
 const { startViewerCountMonitoring, stopViewerCountMonitoring } = require('./src/viewerMonitoring.js');
+const { HueController } = require('./src/hueControl.js');
 
 // Setup loggers
 const log = getLogger('app');
 const discordLog = getLogger('discord');
 const twitchLog = getLogger('twitch');
 const extralifeLog = getLogger('extralife');
+const hueLog = getLogger('hue');
 
 // Parse and validate configuration
 const config = parseConfiguration();
@@ -23,8 +25,18 @@ if (!config.isValid) {
 }
 
 log.info(`ExtraLife Helper Bot starting for participant ${config.participantId}`);
-log.info('All services configured and enabled: Discord, Twitch, Voice, Game Updates');
+log.info('All services configured and enabled: Discord, Twitch, Voice, Game Updates, Hue');
 log.info(`Admin users: Discord=${config.discord.admins.length}, Twitch=${config.twitch.admins.length}`);
+
+// Initialize Hue controller
+const hueController = new HueController(config, hueLog);
+hueController.initialize().then(success => {
+    if (success) {
+        log.info('Hue Bridge connected and ready for celebrations');
+    } else {
+        log.warn('Hue Bridge connection failed - light celebrations will be skipped');
+    }
+});
 
 // Setup a formatter
 const moneyFormatter = new Intl.NumberFormat('en-US', {
@@ -86,7 +98,7 @@ discordClient.on('messageCreate', async (message) => {
             username: message.author.username
         };
         const clients = { discord: discordClient };
-        const response = await handleCommand(command, 'discord', context, config, clients, discordLog);
+        const response = await handleCommand(command, 'discord', context, config, clients, discordLog, hueController);
 
         if (response) {
             message.reply(response);
@@ -143,7 +155,7 @@ twitchClient.on('message', async (channel, tags, message, self) => {
             username: tags['display-name'] || tags.username
         };
         const clients = { discord: discordClient, twitch: twitchClient };
-        const response = await handleCommand(command, 'twitch', context, config, clients, twitchLog);
+        const response = await handleCommand(command, 'twitch', context, config, clients, twitchLog, hueController);
 
         if (response) {
             twitchClient.say(channel, response);
@@ -186,6 +198,11 @@ function getLatestDonation(silent = false) {
             if (twitchClient) {
                 msgQueue.forEach(msg => twitchClient.say(config.twitch.channel, msg.twitch));
             }
+
+            // Trigger Hue celebration lights
+            hueController.celebrateDonation().catch(err => {
+                hueLog.error('Hue celebration failed', { err });
+            });
 
             // 5 seconds later, get the latest summary
             setTimeout(updateDiscordSummary, 5000);

--- a/env.example
+++ b/env.example
@@ -33,3 +33,8 @@ TWITCH_REFRESH_TOKEN=your_refresh_token_here
 # Format: command1:"response1",command2:"response2"
 # Example: CUSTOM_RESPONSES=donate:"Check out my donation link: https://donate.example.com",discord:"Join our Discord: https://discord.gg/example"
 CUSTOM_RESPONSES=
+
+# Philips Hue Configuration (required - for celebration light shows on donations)
+HUE_USERNAME=your_hue_bridge_username_here
+HUE_IPADDRESS=your_hue_bridge_ip_address_here
+HUE_GROUPID=your_hue_group_id_here

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "discord.js": "^14.5.0",
         "dotenv": "^17.2.2",
         "extra-life-api": "^8.0.0",
+        "node-hue-api": "^5.0.0-beta.16",
         "tmi.js": "^1.8.5",
         "winston": "^3.17.0"
       },
@@ -1727,6 +1728,15 @@
         "@octokit/openapi-types": "^26.0.0"
       }
     },
+    "node_modules/@peter-murray/hue-bridge-model": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@peter-murray/hue-bridge-model/-/hue-bridge-model-2.1.1.tgz",
+      "integrity": "sha512-RdnTRY6YOP0TS1z7elRuvD2LsxV+/fwZsl967Ihwvk/SUjQ0247plc6YRM2bEeDBUi06HpcE+tGV4GQBMlVAeg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3046,7 +3056,6 @@
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -6556,6 +6565,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-dns-sd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/node-dns-sd/-/node-dns-sd-1.0.1.tgz",
+      "integrity": "sha512-GCL6FgvkHoDnvJ1Yamf8mY16lYymWmYxjne4q1MC9C8sTZn9XR3BbwsrBQGikMESMFDFLC5MovNZn6wFl1yrdQ==",
+      "license": "MIT"
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -6590,6 +6605,21 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-hue-api": {
+      "version": "5.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/node-hue-api/-/node-hue-api-5.0.0-beta.16.tgz",
+      "integrity": "sha512-JsCQlhOt9e556zzb50BzsMjQ2/Pj1J6srtQS+6mwAhjXsCMT8jm6wEmQCDb7sXVn+5LFtKpq4nmYix1fBWtm8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@peter-murray/hue-bridge-model": "^2.0.1",
+        "bottleneck": "^2.19.5",
+        "node-dns-sd": "^1.0.1",
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "discord.js": "^14.5.0",
     "dotenv": "^17.2.2",
     "extra-life-api": "^8.0.0",
+    "node-hue-api": "^5.0.0-beta.16",
     "tmi.js": "^1.8.5",
     "winston": "^3.17.0"
   },

--- a/src/commands.js
+++ b/src/commands.js
@@ -17,9 +17,10 @@ const moneyFormatter = new Intl.NumberFormat('en-US', {
  * @param {Object} config - Application configuration
  * @param {Object} clients - Discord and Twitch clients
  * @param {Object} logger - Logger instance
+ * @param {Object} hueController - Hue controller instance (optional)
  * @returns {Promise<string|null>} Response message or null if command not found
  */
-async function handleCommand(command, platform, context, config, clients, logger) {
+async function handleCommand(command, platform, context, config, clients, logger, hueController = null) {
     // Convert command to lowercase for case-insensitive matching
     const normalizedCommand = command.toLowerCase();
 
@@ -30,6 +31,9 @@ async function handleCommand(command, platform, context, config, clients, logger
 
     case 'promote':
         return await handlePromoteCommand(platform, context, config, clients, logger);
+
+    case 'testlights':
+        return await handleTestLightsCommand(platform, context, config, hueController, logger);
     }
 
     // Check for custom responses
@@ -127,8 +131,50 @@ async function handlePromoteCommand(platform, context, config, clients, logger) 
     }
 }
 
+/**
+ * Handles the testlights command - admin only command to test Hue lights
+ * @param {string} platform - 'discord' or 'twitch'
+ * @param {Object} context - Command context
+ * @param {Object} config - Application configuration
+ * @param {Object} hueController - Hue controller instance
+ * @param {Object} logger - Logger instance
+ * @returns {Promise<string>} Response message
+ */
+async function handleTestLightsCommand(platform, context, config, hueController, logger) {
+    // Check admin permissions
+    if (!isAdmin(platform, context.userId, config)) {
+        logger.warn('Unauthorized testlights command attempt', {
+            platform,
+            userId: context.userId,
+            username: context.username
+        });
+        return 'You do not have permission to use this command.';
+    }
+
+    if (!hueController) {
+        logger.warn('Hue controller not available for testlights command');
+        return 'Hue controller not available.';
+    }
+
+    try {
+        // Simulate a donation by triggering celebration lights
+        await hueController.celebrateDonation();
+
+        logger.info('Test lights command executed', {
+            platform,
+            executedBy: context.username
+        });
+
+        return '🎉 Testing Hue lights! Simulating a donation celebration...';
+    } catch (err) {
+        logger.error('Error executing testlights command', { error: err.message });
+        return 'Error testing Hue lights.';
+    }
+}
+
 module.exports = {
     handleCommand,
     handleGoalCommand,
-    handlePromoteCommand
+    handlePromoteCommand,
+    handleTestLightsCommand
 };

--- a/src/config.js
+++ b/src/config.js
@@ -26,7 +26,11 @@ function parseConfiguration() {
         // Game update required vars
         'DISCORD_GAME_UPDATE_USER_ID',
         'TWITCH_CLIENT_SECRET',
-        'TWITCH_REFRESH_TOKEN'
+        'TWITCH_REFRESH_TOKEN',
+        // Hue required vars
+        'HUE_USERNAME',
+        'HUE_IPADDRESS',
+        'HUE_GROUPID'
     ];
 
     // Check all required variables
@@ -67,6 +71,11 @@ function parseConfiguration() {
         gameUpdates: {
             userId: process.env.DISCORD_GAME_UPDATE_USER_ID,
             messageTemplate: process.env.DISCORD_GAME_UPDATE_MESSAGE || 'Now playing {game}!'
+        },
+        hue: {
+            username: process.env.HUE_USERNAME,
+            ipAddress: process.env.HUE_IPADDRESS,
+            groupId: process.env.HUE_GROUPID
         },
         customResponses: customResponses
     };

--- a/src/hueControl.js
+++ b/src/hueControl.js
@@ -1,0 +1,227 @@
+const { v3 } = require('node-hue-api');
+
+// Celebration colors in CIE xy coordinates
+const CELEBRATION_COLORS = [
+    { x: 0.2011, y: 0.4433 },  // ExtraLife blue #1AC1DD (in CIE xy coordinates)
+    { x: 0.542, y: 0.303 },    // Red
+    { x: 0.313, y: 0.330 }     // White
+];
+
+// Animation settings
+const ANIMATION_DURATION = 5000; // 5 seconds total
+const FLASH_INTERVAL = 300;      // Flash every 300ms for quick flashing
+const RESTORE_DELAY = 100;       // Small delay between light restorations
+
+/**
+ * Hue Bridge Controller
+ */
+class HueController {
+    constructor(config, logger) {
+        this.config = config;
+        this.logger = logger;
+        this.api = null;
+        this.group = null;
+        this.connected = false;
+        this.isCelebrating = false;
+    }
+
+    /**
+     * Initialize connection to Hue Bridge
+     */
+    async initialize() {
+        try {
+            this.api = await v3.api.createLocal(this.config.hue.ipAddress)
+                .connect(this.config.hue.username);
+            this.connected = true;
+            this.logger.info(`Connected to Hue Bridge at ${this.config.hue.ipAddress}`);
+
+            // Verify the group exists
+            const groups = await this.api.groups.getAll();
+            const targetGroup = groups.find(group => group.id === parseInt(this.config.hue.groupId));
+            if (!targetGroup) {
+                throw new Error(`Group ${this.config.hue.groupId} not found on Hue Bridge`);
+            }
+
+            this.group = targetGroup;
+            this.logger.info(`Found Hue Group: "${targetGroup.name}" (${targetGroup.lights.length} lights)`);
+            return true;
+        } catch (error) {
+            this.logger.error('Failed to initialize Hue Bridge connection', { error: error.message });
+            this.connected = false;
+            return false;
+        }
+    }
+
+    /**
+     * Get all lights in the configured group
+     */
+    async getGroupLights() {
+        if (!this.connected || !this.api || !this.group) {
+            throw new Error('Hue Bridge not connected');
+        }
+
+        // Get detailed light information
+        const lights = [];
+        for (const lightId of this.group.lights) {
+            try {
+                const light = await this.api.lights.getLight(lightId);
+                lights.push(light);
+            } catch (error) {
+                this.logger.warn(`Failed to get light ${lightId}`, { error: error.message });
+            }
+        }
+
+        return lights;
+    }
+
+    /**
+     * Save the current state of all lights
+     */
+    async saveLightStates(lights) {
+        const states = new Map();
+
+        for (const light of lights) {
+            states.set(light.id, {
+                on: light.state.on,
+                bri: light.state.bri,
+                colormode: light.state.colormode,
+                xy: light.state.xy ? [...light.state.xy] : null,
+                hue: light.state.hue,
+                sat: light.state.sat,
+                ct: light.state.ct
+            });
+        }
+
+        return states;
+    }
+
+    /**
+     * Restore lights to their saved states
+     */
+    async restoreLightStates(savedStates) {
+        for (const [lightId, state] of savedStates) {
+            try {
+                const lightState = new v3.lightStates.LightState()
+                    .on(state.on)
+                    .bri(state.bri);
+
+                // Restore color based on the original color mode
+                if (state.colormode === 'xy' && state.xy) {
+                    lightState.xy(state.xy[0], state.xy[1]);
+                } else if (state.colormode === 'hs' && state.hue !== undefined && state.sat !== undefined) {
+                    lightState.hue(state.hue).sat(state.sat);
+                } else if (state.colormode === 'ct' && state.ct) {
+                    lightState.ct(state.ct);
+                }
+
+                await this.api.lights.setLightState(lightId, lightState);
+
+                // Small delay to prevent overwhelming the bridge
+                await this.sleep(RESTORE_DELAY);
+            } catch (error) {
+                this.logger.warn(`Failed to restore light ${lightId}`, { error: error.message });
+            }
+        }
+    }
+
+    /**
+     * Perform celebration light show
+     */
+    async celebrateDonation() {
+        if (!this.connected) {
+            this.logger.warn('Hue Bridge not connected, skipping celebration');
+            return;
+        }
+
+        if (this.isCelebrating) {
+            this.logger.info('Hue celebration already in progress, skipping');
+            return;
+        }
+
+        try {
+            this.isCelebrating = true;
+            this.logger.info('Starting Hue celebration light show');
+
+            // Get all lights in the group
+            const lights = await this.getGroupLights();
+            if (lights.length === 0) {
+                this.logger.warn('No lights found in group, skipping celebration');
+                return;
+            }
+
+            // Save current states
+            const savedStates = await this.saveLightStates(lights);
+
+            // Start the celebration animation
+            const animationPromise = this.runCelebrationAnimation(lights);
+
+            // Set a timeout to restore states after animation duration
+            setTimeout(async () => {
+                try {
+                    await this.restoreLightStates(savedStates);
+                    this.logger.info('Hue celebration completed, lights restored');
+                } catch (error) {
+                    this.logger.error('Failed to restore light states after celebration', { error: error.message });
+                } finally {
+                    this.isCelebrating = false;
+                }
+            }, ANIMATION_DURATION);
+
+            // Don't await the animation to avoid blocking donation processing
+            animationPromise.catch(error => {
+                this.logger.error('Celebration animation failed', { error: error.message });
+            });
+
+        } catch (error) {
+            this.logger.error('Failed to start Hue celebration', { error: error.message });
+            this.isCelebrating = false;
+        }
+    }
+
+    /**
+     * Run the celebration animation
+     */
+    async runCelebrationAnimation(lights) {
+        const endTime = Date.now() + ANIMATION_DURATION;
+
+        while (Date.now() < endTime) {
+            // Flash all lights with random colors
+            await this.flashLightsWithRandomColors(lights);
+
+            // Wait before next flash
+            await this.sleep(FLASH_INTERVAL);
+        }
+    }
+
+    /**
+     * Flash all lights with random colors
+     */
+    async flashLightsWithRandomColors(lights) {
+        const promises = lights.map(async (light) => {
+            try {
+                // Pick a random color for each light
+                const color = CELEBRATION_COLORS[Math.floor(Math.random() * CELEBRATION_COLORS.length)];
+
+                const lightState = new v3.lightStates.LightState()
+                    .on(true)
+                    .brightness(100) // Maximum brightness
+                    .xy(color.x, color.y);
+
+                await this.api.lights.setLightState(light.id, lightState);
+            } catch (error) {
+                this.logger.warn(`Failed to flash light ${light.id}`, { error: error.message });
+            }
+        });
+
+        await Promise.all(promises);
+    }
+
+    /**
+     * Utility: Sleep for specified milliseconds
+     */
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+}
+
+module.exports = { HueController };

--- a/src/hueControl.js
+++ b/src/hueControl.js
@@ -146,6 +146,7 @@ class HueController {
             const lights = await this.getGroupLights();
             if (lights.length === 0) {
                 this.logger.warn('No lights found in group, skipping celebration');
+                this.isCelebrating = false;
                 return;
             }
 

--- a/tests/commands.test.js
+++ b/tests/commands.test.js
@@ -1,4 +1,4 @@
-const { handleCommand, handleGoalCommand, handlePromoteCommand } = require('../src/commands.js');
+const { handleCommand, handleGoalCommand, handlePromoteCommand, handleTestLightsCommand } = require('../src/commands.js');
 const { getUserInfo } = require('extra-life-api');
 
 // Mock the external API
@@ -268,6 +268,82 @@ describe('Commands Module', () => {
             const result = await handleCommand('donate', 'discord', {}, config, {}, mockLogger);
 
             expect(result).toBeNull();
+        });
+    });
+
+    describe('handleTestLightsCommand', () => {
+        const mockConfig = {
+            discord: { admins: ['admin123'] },
+            twitch: { admins: ['admin_user'] }
+        };
+
+        const mockContext = {
+            userId: 'admin123',
+            username: 'admin_user'
+        };
+
+        test('should deny access to non-admin users', async () => {
+            const nonAdminContext = {
+                userId: 'regular_user',
+                username: 'regular_user'
+            };
+
+            const result = await handleTestLightsCommand('discord', nonAdminContext, mockConfig, null, mockLogger);
+
+            expect(result).toBe('You do not have permission to use this command.');
+            expect(mockLogger.warn).toHaveBeenCalledWith('Unauthorized testlights command attempt', {
+                platform: 'discord',
+                userId: 'regular_user',
+                username: 'regular_user'
+            });
+        });
+
+        test('should handle missing Hue controller', async () => {
+            const result = await handleTestLightsCommand('discord', mockContext, mockConfig, null, mockLogger);
+
+            expect(result).toBe('Hue controller not available.');
+            expect(mockLogger.warn).toHaveBeenCalledWith('Hue controller not available for testlights command');
+        });
+
+        test('should handle Hue connection test failure', async () => {
+            const mockHueController = {
+                celebrateDonation: jest.fn().mockRejectedValue(new Error('Bridge not found'))
+            };
+
+            const result = await handleTestLightsCommand('discord', mockContext, mockConfig, mockHueController, mockLogger);
+
+            expect(result).toBe('Error testing Hue lights.');
+            expect(mockLogger.error).toHaveBeenCalledWith('Error executing testlights command', {
+                error: 'Bridge not found'
+            });
+        });
+
+        test('should successfully test Hue lights', async () => {
+            const mockHueController = {
+                celebrateDonation: jest.fn().mockResolvedValue()
+            };
+
+            const result = await handleTestLightsCommand('discord', mockContext, mockConfig, mockHueController, mockLogger);
+
+            expect(result).toBe('🎉 Testing Hue lights! Simulating a donation celebration...');
+            expect(mockHueController.celebrateDonation).toHaveBeenCalled();
+            expect(mockLogger.info).toHaveBeenCalledWith('Test lights command executed', {
+                platform: 'discord',
+                executedBy: 'admin_user'
+            });
+        });
+
+        test('should handle celebration failure', async () => {
+            const mockHueController = {
+                celebrateDonation: jest.fn().mockRejectedValue(new Error('Celebration failed'))
+            };
+
+            const result = await handleTestLightsCommand('discord', mockContext, mockConfig, mockHueController, mockLogger);
+
+            expect(result).toBe('Error testing Hue lights.');
+            expect(mockLogger.error).toHaveBeenCalledWith('Error executing testlights command', {
+                error: 'Celebration failed'
+            });
         });
     });
 });

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -198,6 +198,9 @@ describe('Config Module', () => {
             process.env.TWITCH_CLIENT_SECRET = 'client-secret';
             process.env.TWITCH_REFRESH_TOKEN = 'refresh-token';
             process.env.DISCORD_GAME_UPDATE_USER_ID = '987654321';
+            process.env.HUE_USERNAME = 'hue-username';
+            process.env.HUE_IPADDRESS = '192.168.1.100';
+            process.env.HUE_GROUPID = '1';
 
             const config = parseConfiguration();
             expect(config.isValid).toBe(true);
@@ -205,6 +208,9 @@ describe('Config Module', () => {
             expect(config.participantId).toBe('12345');
             expect(config.discord.token).toBe('discord-token');
             expect(config.twitch.username).toBe('testbot');
+            expect(config.hue.username).toBe('hue-username');
+            expect(config.hue.ipAddress).toBe('192.168.1.100');
+            expect(config.hue.groupId).toBe('1');
         });
 
         test('should return error when required vars missing', () => {
@@ -259,6 +265,9 @@ describe('Config Module', () => {
             process.env.DISCORD_GAME_UPDATE_USER_ID = '987654321';
             process.env.TWITCH_CLIENT_SECRET = 'client-secret';
             process.env.TWITCH_REFRESH_TOKEN = 'refresh-token';
+            process.env.HUE_USERNAME = 'hue-username';
+            process.env.HUE_IPADDRESS = '192.168.1.100';
+            process.env.HUE_GROUPID = '1';
 
             const config = parseConfiguration();
             expect(config.isValid).toBe(true);
@@ -271,6 +280,8 @@ describe('Config Module', () => {
             process.env.DISCORD_TOKEN = 'discord-token';
             process.env.DISCORD_DONATION_CHANNEL = '111111';
             process.env.DISCORD_SUMMARY_CHANNEL = '222222';
+            process.env.DISCORD_WAITING_ROOM_CHANNEL = '333333';
+            process.env.DISCORD_LIVE_ROOM_CHANNEL = '444444';
             process.env.TWITCH_CHANNEL = 'testchannel';
             process.env.TWITCH_USERNAME = 'testbot';
             process.env.TWITCH_CHAT_OAUTH = 'oauth:chat-token';
@@ -278,6 +289,9 @@ describe('Config Module', () => {
             process.env.DISCORD_GAME_UPDATE_USER_ID = '987654321';
             process.env.TWITCH_CLIENT_SECRET = 'client-secret';
             process.env.TWITCH_REFRESH_TOKEN = 'refresh-token';
+            process.env.HUE_USERNAME = 'hue-username';
+            process.env.HUE_IPADDRESS = '192.168.1.100';
+            process.env.HUE_GROUPID = '1';
             process.env.DISCORD_GAME_UPDATE_MESSAGE = 'Now playing: {game}';
 
             const config = parseConfiguration();
@@ -349,6 +363,9 @@ describe('Config Module', () => {
             process.env.TWITCH_CLIENT_SECRET = 'client-secret';
             process.env.TWITCH_REFRESH_TOKEN = 'refresh-token';
             process.env.DISCORD_GAME_UPDATE_USER_ID = '987654321';
+            process.env.HUE_USERNAME = 'hue-username';
+            process.env.HUE_IPADDRESS = '192.168.1.100';
+            process.env.HUE_GROUPID = '1';
             process.env.CUSTOM_RESPONSES = 'donate:"Check out my donation link!",info:"This is some info"';
 
             const config = parseConfiguration();
@@ -378,6 +395,29 @@ describe('Config Module', () => {
             expect(config.isValid).toBe(false);
             expect(config.errors.length).toBeGreaterThan(0);
             expect(config.errors.some(error => error.includes('conflicts with built-in command'))).toBe(true);
+        });
+
+        test('should return error when Hue vars are missing', () => {
+            process.env.EXTRALIFE_PARTICIPANT_ID = '12345';
+            process.env.DISCORD_TOKEN = 'discord-token';
+            process.env.DISCORD_DONATION_CHANNEL = '111111';
+            process.env.DISCORD_SUMMARY_CHANNEL = '222222';
+            process.env.DISCORD_WAITING_ROOM_CHANNEL = '333333';
+            process.env.DISCORD_LIVE_ROOM_CHANNEL = '444444';
+            process.env.TWITCH_USERNAME = 'testbot';
+            process.env.TWITCH_CHAT_OAUTH = 'oauth:chat-token';
+            process.env.TWITCH_CHANNEL = 'testchannel';
+            process.env.TWITCH_CLIENT_ID = 'client-id';
+            process.env.TWITCH_CLIENT_SECRET = 'client-secret';
+            process.env.TWITCH_REFRESH_TOKEN = 'refresh-token';
+            process.env.DISCORD_GAME_UPDATE_USER_ID = '987654321';
+            // Missing HUE_USERNAME, HUE_IPADDRESS, HUE_GROUPID
+
+            const config = parseConfiguration();
+            expect(config.isValid).toBe(false);
+            expect(config.errors).toContain('HUE_USERNAME is a required environment variable');
+            expect(config.errors).toContain('HUE_IPADDRESS is a required environment variable');
+            expect(config.errors).toContain('HUE_GROUPID is a required environment variable');
         });
     });
 });

--- a/tests/hueControl.test.js
+++ b/tests/hueControl.test.js
@@ -1,0 +1,260 @@
+const { HueController } = require('../src/hueControl.js');
+
+// Mock node-hue-api
+jest.mock('node-hue-api', () => ({
+    v3: {
+        api: {
+            createLocal: jest.fn(),
+        },
+        lightStates: {
+            LightState: jest.fn().mockImplementation(() => ({
+                on: jest.fn().mockReturnThis(),
+                brightness: jest.fn().mockReturnThis(),
+                xy: jest.fn().mockReturnThis(),
+                hue: jest.fn().mockReturnThis(),
+                sat: jest.fn().mockReturnThis(),
+                ct: jest.fn().mockReturnThis()
+            }))
+        }
+    }
+}));
+
+describe('HueController', () => {
+    const mockConfig = {
+        hue: {
+            ipAddress: '192.168.1.100',
+            username: 'test-username',
+            groupId: '1'
+        }
+    };
+
+    const mockLogger = {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn()
+    };
+
+    let hueController;
+    let mockApi;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        hueController = new HueController(mockConfig, mockLogger);
+
+        // Setup mock API
+        mockApi = {
+            groups: {
+                getAll: jest.fn(),
+                getGroup: jest.fn(),
+                getGroupByName: jest.fn()
+            },
+            lights: {
+                getLight: jest.fn(),
+                setLightState: jest.fn()
+            },
+            configuration: {
+                getConfiguration: jest.fn()
+            }
+        };
+
+        const { v3 } = require('node-hue-api');
+        v3.api.createLocal.mockReturnValue({
+            connect: jest.fn().mockResolvedValue(mockApi)
+        });
+    });
+
+    describe('initialize', () => {
+        test('should successfully connect to Hue Bridge', async () => {
+            const mockGroups = [
+                { id: 1, name: 'Living Room', lights: ['1', '2', '3'] }
+            ];
+
+            mockApi.groups.getAll.mockResolvedValue(mockGroups);
+
+            const result = await hueController.initialize();
+
+            expect(result).toBe(true);
+            expect(hueController.connected).toBe(true);
+            expect(mockLogger.info).toHaveBeenCalledWith('Connected to Hue Bridge at 192.168.1.100');
+            expect(mockLogger.info).toHaveBeenCalledWith('Found Hue Group: "Living Room" (3 lights)');
+        });
+
+        test('should handle missing group error', async () => {
+            const mockGroups = [
+                { id: 2, name: 'Kitchen', lights: ['4', '5'] }
+            ];
+
+            mockApi.groups.getAll.mockResolvedValue(mockGroups);
+
+            const result = await hueController.initialize();
+
+            expect(result).toBe(false);
+            expect(hueController.connected).toBe(false);
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Failed to initialize Hue Bridge connection',
+                { error: 'Group 1 not found on Hue Bridge' }
+            );
+        });
+
+        test('should handle connection error', async () => {
+            const { v3 } = require('node-hue-api');
+            v3.api.createLocal.mockReturnValue({
+                connect: jest.fn().mockRejectedValue(new Error('Connection failed'))
+            });
+
+            const result = await hueController.initialize();
+
+            expect(result).toBe(false);
+            expect(hueController.connected).toBe(false);
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                'Failed to initialize Hue Bridge connection',
+                { error: 'Connection failed' }
+            );
+        });
+    });
+
+    describe('getGroupLights', () => {
+        beforeEach(() => {
+            hueController.connected = true;
+            hueController.api = mockApi;
+        });
+
+        test('should get lights by group ID', async () => {
+            const mockGroup = { lights: ['1', '2'] };
+            const mockLights = [
+                { id: '1', state: { on: true, bri: 254 } },
+                { id: '2', state: { on: false, bri: 100 } }
+            ];
+
+            hueController.connected = true;
+            hueController.api = mockApi;
+            hueController.group = mockGroup; // Set the group directly
+            mockApi.lights.getLight.mockResolvedValueOnce(mockLights[0]);
+            mockApi.lights.getLight.mockResolvedValueOnce(mockLights[1]);
+
+            const result = await hueController.getGroupLights();
+
+            expect(result).toEqual(mockLights);
+        });
+
+        test('should throw error when not connected', async () => {
+            hueController.connected = false;
+
+            await expect(hueController.getGroupLights()).rejects.toThrow('Hue Bridge not connected');
+        });
+
+        test('should throw error when group not found', async () => {
+            hueController.connected = true;
+            hueController.api = mockApi;
+            hueController.group = null; // No group set
+
+            await expect(hueController.getGroupLights()).rejects.toThrow('Hue Bridge not connected');
+        });
+    });
+
+    describe('saveLightStates', () => {
+        test('should save current light states', async () => {
+            const mockLights = [
+                {
+                    id: '1',
+                    state: {
+                        on: true,
+                        bri: 254,
+                        colormode: 'xy',
+                        xy: [0.3, 0.4],
+                        hue: 12000,
+                        sat: 200,
+                        ct: 366
+                    }
+                },
+                {
+                    id: '2',
+                    state: {
+                        on: false,
+                        bri: 100,
+                        colormode: 'ct',
+                        xy: null,
+                        hue: undefined,
+                        sat: undefined,
+                        ct: 200
+                    }
+                }
+            ];
+
+            const result = await hueController.saveLightStates(mockLights);
+
+            expect(result.size).toBe(2);
+            expect(result.get('1')).toEqual({
+                on: true,
+                bri: 254,
+                colormode: 'xy',
+                xy: [0.3, 0.4],
+                hue: 12000,
+                sat: 200,
+                ct: 366
+            });
+            expect(result.get('2')).toEqual({
+                on: false,
+                bri: 100,
+                colormode: 'ct',
+                xy: null,
+                hue: undefined,
+                sat: undefined,
+                ct: 200
+            });
+        });
+    });
+
+    describe('celebrateDonation', () => {
+        test('should skip celebration when not connected', async () => {
+            hueController.connected = false;
+
+            await hueController.celebrateDonation();
+
+            expect(mockLogger.warn).toHaveBeenCalledWith('Hue Bridge not connected, skipping celebration');
+        });
+
+        test('should skip celebration when no lights found', async () => {
+            hueController.connected = true;
+            hueController.api = mockApi;
+            hueController.group = { lights: [] }; // Empty lights array
+
+            await hueController.celebrateDonation();
+
+            expect(mockLogger.warn).toHaveBeenCalledWith('No lights found in group, skipping celebration');
+        });
+
+        test('should start celebration with lights', async () => {
+            hueController.connected = true;
+            hueController.api = mockApi;
+
+            const mockGroup = { lights: ['1', '2'] };
+            const mockLights = [
+                { id: '1', state: { on: true, bri: 254, colormode: 'xy', xy: [0.3, 0.4] } },
+                { id: '2', state: { on: false, bri: 100, colormode: 'ct', ct: 200 } }
+            ];
+
+            mockApi.groups.getGroup.mockResolvedValue(mockGroup);
+            mockApi.lights.getLight.mockResolvedValueOnce(mockLights[0]);
+            mockApi.lights.getLight.mockResolvedValueOnce(mockLights[1]);
+            mockApi.lights.setLightState.mockResolvedValue();
+
+            // Mock the celebration animation to avoid timing issues in tests
+            jest.spyOn(hueController, 'runCelebrationAnimation').mockResolvedValue();
+
+            await hueController.celebrateDonation();
+
+            expect(mockLogger.info).toHaveBeenCalledWith('Starting Hue celebration light show');
+        });
+    });
+
+    describe('utility methods', () => {
+        test('sleep should wait for specified time', async () => {
+            const start = Date.now();
+            await hueController.sleep(50);
+            const end = Date.now();
+
+            expect(end - start).toBeGreaterThanOrEqual(40); // Allow some tolerance
+        });
+    });
+});

--- a/tests/hueControl.test.js
+++ b/tests/hueControl.test.js
@@ -126,8 +126,6 @@ describe('HueController', () => {
                 { id: '2', state: { on: false, bri: 100 } }
             ];
 
-            hueController.connected = true;
-            hueController.api = mockApi;
             hueController.group = mockGroup; // Set the group directly
             mockApi.lights.getLight.mockResolvedValueOnce(mockLights[0]);
             mockApi.lights.getLight.mockResolvedValueOnce(mockLights[1]);


### PR DESCRIPTION
- Flash all Hue lights in celebratory colors when donations are received
- Add !testlights admin command for testing
- Include complete setup documentation and environment configuration
- Graceful error handling preserves bot functionality if Hue unavailable